### PR TITLE
Update README.md for 2.12

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 # KeY Project
 
 The KeY project provides a Deductive Java Program Verifier. This verifier is an interactive theorem prover designed for the verification of Java programs.
-You can find more information on KeY on our [website](https://key-project.org) or in use the documentation in the companion repository [key-docs](https://github.com/KeYProject/key-docs).
+You can find more information on KeY on our [website](https://key-project.org) and in the [documentation](https://keyproject.github.io/key-docs/).
 
-The current version is 2.10.0, licensed under GPL v2.
+The current version is [2.12.0](https://github.com/KeYProject/key/releases/tag/KeY-2.12.0), licensed under GPL v2.


### PR DESCRIPTION
The current version is 2.12, not 2.10. And I think it is better to link to the rendered docs, not the source repo.